### PR TITLE
Revert "Rename gem name, original `casbin` name already taken."

### DIFF
--- a/casbin.gemspec
+++ b/casbin.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'casbin/version'
 
 Gem::Specification.new do |s|
-  s.name        = 'casbin-ruby'
+  s.name        = 'casbin'
   s.version     = Casbin::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Igor Kutyavin']


### PR DESCRIPTION
Reverts evrone/casbin-ruby#29